### PR TITLE
Add `<input />` components for React

### DIFF
--- a/components/react-ts/button.tsx
+++ b/components/react-ts/button.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/utils/cn'
 import React, { type ButtonHTMLAttributes, forwardRef } from 'react'
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>
@@ -7,6 +8,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>
 /**
  * Button component from Apa UI
  */
+// eslint-disable-next-line react/display-name
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(({ children, className, ...props }) => (
     <button
         className={cn(

--- a/components/react-ts/input.tsx
+++ b/components/react-ts/input.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/utils/cn'
+import * as React from 'react'
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+    ({ className, type, ...props }, ref) => {
+        return (
+            <input
+                type={type}
+                className={cn(
+                    'flex h-10 w-full rounded-md border-2 border-black shadow-[2px_2px_0_0_#000] bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:shadow-none focus-visible:translate-y-[2px] focus-visible:translate-x-[2px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm transition-all',
+                    className
+                )}
+                ref={ref}
+                {...props}
+            />
+        )
+    }
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/components/react/button.jsx
+++ b/components/react/button.jsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/utils/cn'
 import { forwardRef } from 'react'
 
 /**


### PR DESCRIPTION
edited by @sensasi-delight:

This pull request includes changes to the `components/react-ts` and `components/react` directories to improve the consistency and functionality of the `Button` and `Input` components to fix #7 #24. The most important changes include the addition of the `cn` utility function for class name concatenation and the introduction of a new `Input` component in TypeScript.

Enhancements to components:

* [`components/react-ts/button.tsx`](diffhunk://#diff-e06d3ebac75943ed3290e5e01323152feb668e4f2ff6dfa940c22a5d7623c1ddR3-R11): Added the `cn` utility function for class name concatenation and disabled the ESLint rule for display names in the `Button` component.
* [`components/react-ts/input.tsx`](diffhunk://#diff-51e874bba3271f32b71be9de5180ac5d2150adac5386b80986323eb6fa7e4027R1-R21): Introduced a new `Input` component using the `cn` utility function for class name concatenation and added TypeScript support.
* [`components/react/button.jsx`](diffhunk://#diff-1f8b9da2b36ea7c44c96a3c58885600a1f7d653b1f2d9fd39fc5e95448b10609R3): Added the `cn` utility function for class name concatenation in the `Button` component.