### PR TITLE
fix: Add Node.js setup step to GitHub Actions workflow for branch builds

### DIFF
--- a/.github/workflows/branches-on-push.yml
+++ b/.github/workflows/branches-on-push.yml
@@ -14,6 +14,11 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20.x'
+                  registry-url: 'https://registry.npmjs.org'
+
             - name: Setup bun
               uses: oven-sh/setup-bun@v2
 
@@ -27,4 +32,5 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
               run: bunx semantic-release


### PR DESCRIPTION
Introduce a Node.js setup step in the GitHub Actions workflow to ensure proper environment configuration for branch builds. This change addresses the initial workflow setup requirements outlined in issue #26.