### PR TITLE
ci: Add release configuration for semantic-release

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,0 +1,6 @@
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+    branches: ['master', { name: 'sigma', prerelease: true }],
+}


### PR DESCRIPTION
Introduce a configuration file for semantic-release to manage releases for the master and sigma branches.