### PR TITLE
fix: Update release configuration to use 'main' branch

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -2,5 +2,5 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-    branches: ['master', { name: 'sigma', prerelease: true }],
+    branches: ['main', { name: 'sigma', prerelease: true }],
 }


### PR DESCRIPTION
Change the release configuration to reference the 'main' branch instead of 'master'.