### PR TITLE
ci: update GitHub Actions workflow to add permissions for release publishing and issue commenting

### DIFF
--- a/.github/workflows/branches-on-push.yml
+++ b/.github/workflows/branches-on-push.yml
@@ -6,9 +6,18 @@ on:
             - main
             - sigma
 
+permissions:
+    contents: read # for checkout
+
 jobs:
     build:
         runs-on: ubuntu-latest
+
+        permissions:
+            contents: write # to be able to publish a GitHub release
+            issues: write # to be able to comment on released issues
+            pull-requests: write # to be able to comment on released pull requests
+            id-token: write # to enable use of OIDC for npm provenance
 
         steps:
             - name: Checkout code


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration file `.github/workflows/branches-on-push.yml` to enhance permissions management.

Enhancements to permissions management:

* Added read permissions for contents at the workflow level to enable code checkout.
* Added write permissions for contents, issues, pull-requests, and id-token at the job level to support publishing releases, commenting on issues and pull requests, and using OIDC for npm provenance.