### PR TITLE
refactor: rename build job to release and update token variable in workflow

### DIFF
--- a/.github/workflows/branches-on-push.yml
+++ b/.github/workflows/branches-on-push.yml
@@ -7,7 +7,7 @@ on:
             - sigma
 
 jobs:
-    build:
+    release:
         runs-on: ubuntu-latest
 
         steps:
@@ -31,6 +31,6 @@ jobs:
             - name: Semantic Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
               run: bunx semantic-release


### PR DESCRIPTION
Rename the build job to release for clarity and update the token variable from NPM_TOKEN to NODE_AUTH_TOKEN in the workflow configuration.