### PR TITLE
ci(pr): Add `sigma` branch to CI and update workflow actions

### DIFF
--- a/.github/workflows/branches-on-pr.yml
+++ b/.github/workflows/branches-on-pr.yml
@@ -1,9 +1,10 @@
-name: Main branch on Pull Request
+name: Branches on Pull Request
 
 on:
     pull_request:
         branches:
             - main
+            - sigma
 
 jobs:
     lint:
@@ -23,13 +24,7 @@ jobs:
               run: bun install
 
             - name: Lint code
-              run: bun lint:fix
-
-            - name: Commit linted files if any
-              uses: stefanzweifel/git-auto-commit-action@v5
-              with:
-                  commit_message: 'Auto fix lint error(s)'
-                  file_pattern: '. :!bun.lockb'
+              run: bun lint
 
             # - name: 🧪 MINIMAL ADA TESTING SIH
             #   run: bun run test

--- a/.github/workflows/branches-on-pr.yml
+++ b/.github/workflows/branches-on-pr.yml
@@ -7,7 +7,7 @@ on:
             - sigma
 
 jobs:
-    lint:
+    code-quality:
         runs-on: ubuntu-latest
 
         permissions:
@@ -24,7 +24,7 @@ jobs:
               run: bun install
 
             - name: Lint code
-              run: bun lint
+              run: bun run lint
 
             # - name: 🧪 MINIMAL ADA TESTING SIH
             #   run: bun run test

--- a/.github/workflows/branches-on-pr.yml
+++ b/.github/workflows/branches-on-pr.yml
@@ -24,7 +24,7 @@ jobs:
               run: bun install
 
             - name: Lint code
-              run: bun run lint
+              run: bun run lint:check
 
             # - name: 🧪 MINIMAL ADA TESTING SIH
             #   run: bun run test


### PR DESCRIPTION
Introduce a new workflow for the `sigma` branch, remove automatic commit linting to close #46, and rename the action for better clarity.