### PR TITLE
ci: remove unnecessary newline in branches-on-push workflow

### DIFF
--- a/.github/workflows/branches-on-push.yml
+++ b/.github/workflows/branches-on-push.yml
@@ -41,7 +41,6 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-
               run:
                   - mkdir release
                   - cp -r components/* release


### PR DESCRIPTION
Eliminate an extra newline in the branches-on-push workflow file for improved readability.