### PR TITLE
build: streamline semantic release command in branches-on-push workflow

### DIFF
--- a/.github/workflows/branches-on-push.yml
+++ b/.github/workflows/branches-on-push.yml
@@ -37,17 +37,17 @@ jobs:
             - name: Build Apa-UI
               run: bun run build
 
+            - run: mkdir release
+            - run: cp -r components/* release
+            - run: cp -r dist/* release
+            - run: cp -r utils/* release
+            - run: cp LICENSE release
+            - run: cp README.md release
+            - run: cp package.json release
+            - run: cd release
+
             - name: Semantic Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-              run:
-                  - mkdir release
-                  - cp -r components/* release
-                  - cp -r dist/* release
-                  - cp -r utils/* release
-                  - cp LICENSE release
-                  - cp README.md release
-                  - cp package.json release
-                  - cd release
-                  - bunx semantic-release
+              run: bunx semantic-release


### PR DESCRIPTION
Refactor the branches-on-push workflow to simplify the semantic release command execution. This change enhances readability and maintainability of the workflow file.