### PR TITLE
docs: update documentation and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
-# apa-ui
+# Apa-UI
 
-Under construction:
+> _Coming soon_
 
-```bash
-please wait
-```
+## Development
+
+> _Coming soon_
+
+## Releasing
+
+Since the release process is handled by ['semantic-release'](https://semantic-release.gitbook.io/) you can just follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and the release will be handled automatically. Please consult the references below for more understanding about how the `semantic-release` works:
+
+- [Workflow Configuration](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration)
+- [Release Workflow](https://semantic-release.gitbook.io/semantic-release/recipes/release-workflow)
+- [Commit Message Format](https://semantic-release.gitbook.io/semantic-release#commit-message-format)
+
+## Contributing
+
+> _Coming soon_
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@apa-dev/ui",
-    "module": "index.ts",
+    "author": "Apa Developer",
+    "license": "MIT",
     "type": "module",
     "repository": {
         "type": "git",

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,4 +1,9 @@
 /**
+ * Configuration for semantic-release
+ *
+ * @see https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration
+ * @see https://semantic-release.gitbook.io/semantic-release/usage/configuration
+ *
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {


### PR DESCRIPTION
Remove the `module` property from `package.json` and add `author` and `license` properties. Enhance documentation in the README and semantic-release configuration with additional sections and comments.