### PR TITLE
ci: using `.gitignore` instead remove dev files in workflow

### DIFF
--- a/.github/workflows/branches-on-push.yml
+++ b/.github/workflows/branches-on-push.yml
@@ -37,15 +37,6 @@ jobs:
             - name: Build Apa-UI
               run: bun run build
 
-            # Remove unnecessary files
-            - run: rm -r .github
-            - run: rm -r .husky
-            - run: rm .mergify.yml
-            - run: rm bun.lockb
-            - run: rm commitlint.config.js
-            - run: rm eslint.config.mjs
-            - run: rm release.config.mjs
-
             - name: Semantic Release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,16 @@
+/.github/
+/.husky/
 /src/
 /tests/
 /example/
 .editorconfig
 .gitignore
+.mergify.yml
 .prettierignore
 .prettierrc
+bun.lockb
+commitlint.config.js
 CONTRIBUTING.md
+eslint.config.mjs
+release.config.mjs
 tsconfig.json


### PR DESCRIPTION
This pull request includes changes to the build process and the `.npmignore` file to streamline the workflow and ensure unnecessary files are not included in the npm package.

Changes to the build process:

* [`.github/workflows/branches-on-push.yml`](diffhunk://#diff-a11857455b2de500af15721097e98bef30fb33ca0fd84ad7002dc63e50306e6bL40-L48): Removed steps that delete unnecessary files after the build step.

Updates to `.npmignore`:

* [`.npmignore`](diffhunk://#diff-34958b02363eec9a904716f0b4a8782b021c6b33b2e8599019e36c88e045240bR1-R15): Added entries to ignore `.github`, `.husky`, and several configuration files to prevent them from being included in the npm package.